### PR TITLE
[CHORE] React가 불필요한 상황에서 import하지 않을 경우 ESLint에서 에러를 띄우지 않도록 규칙 변경

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -13,6 +13,12 @@ export default [
 	pluginJs.configs.recommended,
 	...tseslint.configs.recommended,
 	...fixupConfigRules(pluginReactConfig),
-	eslintConfigPrettier, // <--
-	eslintPluginPrettierRecommended, // <--
+	eslintConfigPrettier,
+	eslintPluginPrettierRecommended,
+	{
+		rules: {
+			'react/jsx-uses-react': 'off',
+			'react/react-in-jsx-scope': 'off',
+		},
+	},
 ];


### PR DESCRIPTION
## 이슈 번호
> close #15 

## 작업 요약
<img src="https://github.com/user-attachments/assets/dd5ac847-9806-4c83-ab0a-37fdea6c5477" width="600px" />

본 PR에서는 React를 import하는 것이 불필요한 상황에서도 React를 import하지 않을 경우 ESLint에서 에러를 발생시켜, 이러한 관련 설정들을 비활성화하도록 규칙을 변경했습니다.

비활성화한 규칙:
- `react/jsx-uses-react`
- `react/react-in-jsx-scope': 'off`

ESLint의 본목적을 생각하면 규칙을 함부로 비활성화하는 것은 신중해야 하나, 이 규칙은 이미 광범위하게 알려진 이슈이고, 작업하고 있는 React의 버전이 `v17` 이상이기 때문에, **React의 JSX 컴포넌트를 렌더링하는 과정에서 React에 더 이상 의존하지 않도록** 라이브러리의 로직이 짜여 있습니다. 따라서, 이 규칙들을 비활성화하게 되었습니다.

어떻게 생각하시나요?

## 참고/인용 자료
- https://ko.legacy.reactjs.org/blog/2020/09/22/introducing-the-new-jsx-transform.html#eslint
